### PR TITLE
テンプレートの継承関係を修正(user_form.html)

### DIFF
--- a/app/templates/app/base.html
+++ b/app/templates/app/base.html
@@ -70,7 +70,7 @@
 
 
 
-        {% block content %}{% endblock %}
+        {% block body %}{% endblock %}
     </div>
 </body>
 </html>

--- a/app/templates/app/user_form.html
+++ b/app/templates/app/user_form.html
@@ -1,15 +1,7 @@
-{% extends "app/base.html" %}
+{% extends "app/registration/base.html" %}
 
 {% block content %}
 <div class="row">
-    <div class="col-md-3">
-        <ul class="list-group list-group-flush">
-            <li class="list-group-item"><a href="{% url 'app:profile' %}">プロフィール</a></li>
-            <li class="list-group-item"><a href="{% url 'app:password_change' %}">パスワードの変更</a></li>
-            <li class="list-group-item"><a href="{% url 'app:logout' %}">ログアウト</a></li>
-            <li class="list-group-item"><a href="{% url 'app:delete-confirmation' %}">退会</a></li>
-        </ul>
-    </div>
     <div class="col-md-9">
         <form action="" method="POST" enctype="multipart/form-data">
             {{ form.non_field_errors }}


### PR DESCRIPTION
テンプレートファイルの継承関係は、以下のような想定をしていると思います。

```
app/base.html (全ページ共通のヘッダーとか)
↓
app/registration/base.html (アカウント周りの設定画面に共通のもの。プロフィール、パスワードとか。)
↓
app/user_form.html(プロフィール編集フォーム画面)
```

想定通りの継承関係になっていなかったので、修正をしました。include自体は問題なく設定できていたので、修正していません。
これで、user_form.htmlではリンクを記述する必要がなくなっています。他の画面も同様にしてリンク部分を`registration/base.html`に共通化できるはずです。